### PR TITLE
Fix 3rd party auth callback URLs in prod + other prod fixes

### DIFF
--- a/packages/df-api/index.js
+++ b/packages/df-api/index.js
@@ -18,6 +18,10 @@ const { registerAppLists } = require('./schema');
 const PROJECT_NAME = 'DineForward - Backend';
 
 const keystoneConfig = {
+  appVersion: {
+    addVersionToHttpHeaders: false,
+    access: false,
+  },
   name: PROJECT_NAME,
   adapter: new MongooseAdapter(),
   onConnect: initialiseData,

--- a/packages/df-api/utils/auth/facebook.js
+++ b/packages/df-api/utils/auth/facebook.js
@@ -31,7 +31,6 @@ const init = (ks, commonCfg) =>
 
         resolveCreateData: ({ createData, serviceProfile }, req, res) => {
           if (!serviceProfile) throw new Error(`Facebook auth returned null serviceProfile`);
-          console.log("FB", serviceProfile)
           const email =
             serviceProfile.emails &&
             serviceProfile.emails[0] &&

--- a/packages/df-api/utils/auth/index.js
+++ b/packages/df-api/utils/auth/index.js
@@ -2,13 +2,19 @@ const facebook = require('./facebook');
 const google = require('./google');
 const password = require('./password');
 
-const getOAuthUrls = app => ({
-  loginPath: `/auth/${app}`,
-  callbackPath: `/auth/callback/${app}`,
-  callbackURL: `${process.env.EXTERNAL_URL}/auth/callback/${app}`,
-});
+const getOAuthUrls = app => {
+  const callbackPath = `/auth/callback/${app}`;
+  const loginPath = `/auth/${app}`;
+  const callbackURL = `${process.env.EXTERNAL_URL}${callbackPath}`;
 
-const isDevelopment = process.env.NODE_ENV !== 'production'
+  return {
+    callbackPath,
+    loginPath,
+    strategyConfig: {
+      callbackURL,
+    }
+  };
+};
 
 const authStrategy = ks => {
   const strategies = {};

--- a/packages/runner/utils.js
+++ b/packages/runner/utils.js
@@ -115,9 +115,7 @@ async function executeDefaultServer(args, entryFile, distDir, spinner) {
 
   status = 'db-connect';
 
-  console.log('BEFORE:', app.enabled('x-powered-by'))
   const { middlewares } = await keystone.prepare({ apps, distDir, dev, cors, pinoOptions });
-  console.log('AFTER:', app.enabled('x-powered-by'))
 
   await keystone.connect();
 
@@ -127,7 +125,6 @@ async function executeDefaultServer(args, entryFile, distDir, spinner) {
   app.use(middlewares);
 
   if (!dev) server = await listen();
-  console.log('AFTER2:', app.enabled('x-powered-by'))
 
   status = 'started';
   spinner.succeed(chalk.green.bold(`Keystone instance is ready at http://localhost:${port} 🚀`));


### PR DESCRIPTION
- Fix lack of HTTPS on auth callback URLs
- Remove Keystone version HTTP header
- Don't process requests until DB is up and ready in prod
