### PR TITLE
Adapt deploy fixes for switch over for prod

### DIFF
--- a/adapt/df_api.tsx
+++ b/adapt/df_api.tsx
@@ -37,6 +37,7 @@ export interface DfApiProps {
     facebookAuth: Handle;
     cookieSecret: string;
     scope: NetworkServiceScope;
+    externalUrl?: string;
     cloudRunHack?: boolean;
 }
 
@@ -78,6 +79,7 @@ export function DfApi(props: SFCDeclProps<DfApiProps>) {
         googleAuth,
         facebookAuth,
         cookieSecret,
+        externalUrl,
         cloudRunHack } =
         props as SFCBuildProps<DfApiProps, typeof dfApiDefaultProps>;
 
@@ -87,7 +89,7 @@ export function DfApi(props: SFCDeclProps<DfApiProps>) {
 
     const env = mergeEnvPairs(connections, {
         COOKIE_SECRET: cookieSecret
-    });
+    }, externalUrl ? { EXTERNAL_URL: externalUrl } : {});
 
     const img = handle();
     const netSvc = handle();

--- a/adapt/df_api.tsx
+++ b/adapt/df_api.tsx
@@ -127,6 +127,7 @@ export function DfApi(props: SFCDeclProps<DfApiProps>) {
         {mongo}
         {cloudRunHack
             ? <CloudRunAdapter
+                key={props.key}
                 region={"us-west1"}
                 port={port} image={img}
                 env={env}

--- a/adapt/gcloud/CloudRun.tsx
+++ b/adapt/gcloud/CloudRun.tsx
@@ -62,6 +62,7 @@ export interface CloudRunProps {
     env?: Environment;
     args?: Environment;
     image: string;
+    serviceName?: string;
     //Region should be optional, but for now we'll require it
     region: string;
     port: number;
@@ -297,7 +298,7 @@ export class CloudRun extends Action<CloudRunProps> {
         const key = this.props.key
         if (key == null) throw new Error("Internal Error: key is falsey");
         this.config_ = {
-            name: makeCloudRunName(key, elem.id, deployID),
+            name: this.props.serviceName || makeCloudRunName(key, elem.id, deployID),
             env: mergeEnvSimple(this.props.env) || {},
             args: mergeEnvSimple(this.props.args) || {},
             image: this.props.image,

--- a/adapt/index.tsx
+++ b/adapt/index.tsx
@@ -2,7 +2,7 @@ import Adapt, {
     Group,
     handle
 } from "@adpt/core";
-import { dockerDevStyle, prodStyle } from "./styles";
+import { dockerDevStyle, prodStyle, stageStyle, stageLikeStyle } from "./styles";
 import { MongoDB } from "@adpt/cloud/mongodb";
 import { Redis } from "@adpt/cloud/redis";
 import { Cloudinary, GoogleMaps, GoogleAuth, FacebookAuth } from "./lib";
@@ -41,6 +41,8 @@ Adapt.stack("default", <App />, dockerDevStyle);
 Adapt.stack("local-dev", <App />, dockerDevStyle);
 //cloudRunHack={true} is a temporary workaround because there is no abstract
 //cloud.Service component that renders to gcloud.CloudRun isntances
+Adapt.stack("gcloud-stagelike-dev", <App cloudRunHack={true} />, stageLikeStyle);
+Adapt.stack("gcloud-stage", <App cloudRunHack={true} />, stageStyle)
 Adapt.stack("gcloud-prod", <App cloudRunHack={true} />, prodStyle);
 
 // Testing environments for complex components, should be 

--- a/adapt/index.tsx
+++ b/adapt/index.tsx
@@ -25,7 +25,7 @@ function App(props: { cloudRunHack?: boolean }) {
         <GoogleMaps handle={googleMaps} />
         <GoogleAuth handle={googleAuth} />
         <FacebookAuth handle={facebookAuth} />
-        <DfApi handle={api} port={8080}
+        <DfApi key="df-api" handle={api} port={8080}
             mongo={mongo}
             redis={redis}
             cloudinary={cloudinary}

--- a/adapt/styles.tsx
+++ b/adapt/styles.tsx
@@ -103,33 +103,45 @@ export const dockerDevStyle = concatStyles(commonDevStyle(),
                 }} />)}
     </Style>);
 
-export const prodStyle = <Style>
-    {Redis} {Adapt.rule(() => <RedisProvider uri={`redis://${env.REDIS_HOST}:${env.REDIS_PORT}?password=${env.REDIS_PASSWORD}`} />)}
-    {MongoDB} {Adapt.rule(() => <MongoDBProvider uri={env.MONGO_URI} />)}
-    {Cloudinary} {Adapt.rule(() => <CloudinaryProvider uri={env.CLOUDINARY_URL} />)}
-    {GoogleMaps} {Adapt.rule(() => <GoogleMapsProvider key={env.GOOGLE_MAPS_KEY} />)}
-    {GoogleAuth} {Adapt.rule(() => <GoogleAuthProvider
-        clientId={env.GOOGLE_CLIENT_ID}
-        clientSecret={env.GOOGLE_CLIENT_SECRET} />)}
-    {FacebookAuth} {Adapt.rule(() => <FacebookAuthProvider
-        appId={env.FACEBOOK_APP_ID}
-        appSecret={env.FACEBOOK_APP_SECRET} />)}
+function prodLikeStyle(options: {
+    region: string,
+    cloudRunServiceName?: string
+}) {
+    return <Style>
+        {Redis} {Adapt.rule(() => <RedisProvider uri={`redis://${env.REDIS_HOST}:${env.REDIS_PORT}?password=${env.REDIS_PASSWORD}`} />)}
+        {MongoDB} {Adapt.rule(() => <MongoDBProvider uri={env.MONGO_URI} />)}
+        {Cloudinary} {Adapt.rule(() => <CloudinaryProvider uri={env.CLOUDINARY_URL} />)}
+        {GoogleMaps} {Adapt.rule(() => <GoogleMapsProvider key={env.GOOGLE_MAPS_KEY} />)}
+        {GoogleAuth} {Adapt.rule(() => <GoogleAuthProvider
+            clientId={env.GOOGLE_CLIENT_ID}
+            clientSecret={env.GOOGLE_CLIENT_SECRET} />)}
+        {FacebookAuth} {Adapt.rule(() => <FacebookAuthProvider
+            appId={env.FACEBOOK_APP_ID}
+            appSecret={env.FACEBOOK_APP_SECRET} />)}
 
-    {DfApi} {Adapt.rule<DfApiProps>(({ handle, ...props }, info: StyleBuildInfo) =>
-        ruleNoRematch(info, <DfApi
-            {...{
-                ...props,
-                port: 80,
-                cookieSecret: env.cookieSecret
-            }} />))}
+        {DfApi} {Adapt.rule<DfApiProps>(({ handle, ...props }, info: StyleBuildInfo) =>
+            ruleNoRematch(info, <DfApi
+                {...{
+                    ...props,
+                    port: 80,
+                    cookieSecret: env.cookieSecret,
+                    externalUrl: env.EXTERNAL_URL
+                }} />))}
 
-    {CloudRunAdapter} {Adapt.rule<CloudRunAdapterProps>(({ handle, ...props }, info: StyleBuildInfo) =>
-        ruleNoRematch(info, <CloudRunAdapter
-            {...{
-                ...props,
-                registryUrl: registryUrl(),
-                allowUnauthenticated: true,
-                cpu: 2,
-                memory: "512Mi"
-            }} />))}
-</Style>
+        {CloudRunAdapter} {Adapt.rule<CloudRunAdapterProps>(({ handle, ...props }, info: StyleBuildInfo) =>
+            ruleNoRematch(info, <CloudRunAdapter
+                {...{
+                    ...props,
+                    serviceName: options.cloudRunServiceName,
+                    registryUrl: registryUrl(),
+                    allowUnauthenticated: true,
+                    cpu: 2,
+                    memory: "512Mi",
+                    region: options.region
+                }} />))}
+    </Style>
+}
+
+export const stageLikeStyle = prodLikeStyle({ region: "us-west1" });
+export const stageStyle = prodLikeStyle({ region: "us-west1", cloudRunServiceName: "df-api-stage" });
+export const prodStyle = prodLikeStyle({ region: "us-west1", cloudRunServiceName: "df-api" });


### PR DESCRIPTION
This PR allows Adapt to build and deploy df-api and update the production gcloud service.  Make sure `gcloud` is configured and you are authenticated.  Set your project to "dineforward" and then do:

```shell
#For staging
CLOUDRUN_REGISTRY_URL=gcr.io/dineforward DOTENV=<path to dotenv file> adapt run --deployID df-stage gcloud-stage
```

```shell
#For prod
CLOUDRUN_REGISTRY_URL=gcr.io/dineforward DOTENV=<path to dotenv file> adapt run --deployID df-prod gcloud-prod
```

To udpate do
```
CLOUDRUN_REGISTRY_URL=gcr.io/dineforward DOTENV=<path to detenv file> adapt update <your deployID>
```

You can also use the other style sheets to deploy locally, or deploy a stage-like environment in your own project.

